### PR TITLE
Set default to grub2 provider on el7 based systems

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -18,6 +18,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
     which("grub2-mkconfig") or which("grub-mkconfig") or '/usr/sbin/grub-mkconfig'
   end
 
+  defaultfor :osfamily => 'Redhat', :operatingsystemmajrelease => [ '7' ]
   confine :feature => :augeas
   commands :mkconfig => mkconfig_path
 


### PR DESCRIPTION
On RHEL/CentOS 7 every puppet run shows the following warning if no
default is set:

Warning: Found multiple default providers for kernel_parameter: grub2, grub; using grub2
